### PR TITLE
Allow Chainable to support List<Sobject> based Database.batchable - Internal Salesforce Error

### DIFF
--- a/force-app/main/default/classes/ChainableDataBatch.cls
+++ b/force-app/main/default/classes/ChainableDataBatch.cls
@@ -1,0 +1,62 @@
+public abstract class ChainableDataBatch extends Chainable
+                                     implements Database.Batchable<SObject>, Database.Stateful, Database.AllowsCallouts {
+    // ABSTRACT
+
+    protected abstract Database.QueryLocator start(Context ctx);
+    protected abstract void execute(Context ctx, List<SObject> scope);
+    protected abstract void finish(Context ctx);
+
+
+    // PUBLIC
+
+    public Database.QueryLocator start(Database.BatchableContext ctx) {
+        return start( new Context(ctx) );
+    }
+
+
+    public void execute(Database.BatchableContext ctx, List<SObject> scope) {
+        execute( new Context(ctx), scope );
+    }
+
+
+    public void finish(Database.BatchableContext ctx) {
+        finish( new Context(ctx) );
+
+        executeNext();
+    }
+
+
+    protected virtual Integer batchSize() {
+        return 200;
+    }
+
+
+    public override void executeAsynchronously() {
+        Database.executeBatch(this, batchSize());
+    }
+
+
+    public override void executeSynchronously(Context ctx) {
+        Database.QueryLocator fullScope = start(ctx);
+        Database.QueryLocatorIterator iterator = fullScope.iterator();
+        List<SObject> batchedList = new List<SObject>();
+        Integer batchIndex = 0;
+
+        while(iterator.hasNext()) {
+            batchedList.add(iterator.next());
+            if(batchedList.size() == batchSize()) {
+                batchIndex++;
+                execute(ctx, batchedList);
+                batchedList.clear();
+            }
+            if (Test.isRunningTest() && batchIndex == 1) {
+                break;
+            }
+        }
+        if(!batchedList.isEmpty()) {
+            execute(ctx, batchedList);
+        }
+
+        finish(ctx);
+    }
+}

--- a/force-app/main/default/classes/ChainableDataBatch.cls-meta.xml
+++ b/force-app/main/default/classes/ChainableDataBatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/test/classes/Chainable_Test.cls
+++ b/force-app/main/test/classes/Chainable_Test.cls
@@ -18,6 +18,7 @@ public class Chainable_Test {
 
 									.then( new SampleBatch() )
 									.then( new SampleQueueable() )
+									.then( new SampleDataBatch() )
 
 									.execute();
 
@@ -28,6 +29,9 @@ public class Chainable_Test {
 		System.assertEquals('SampleBatch.execute', (String)calls.next());
 		System.assertEquals('SampleBatch.finish', (String)calls.next());
 		System.assertEquals('SampleQueueable.execute', (String)calls.next());
+		System.assertEquals('SampleDataBatch.start', (String)calls.next());
+		System.assertEquals('SampleDataBatch.execute', (String)calls.next());
+		System.assertEquals('SampleDataBatch.finish', (String)calls.next());
 	}
 
 

--- a/force-app/main/test/classes/Error_Test.cls
+++ b/force-app/main/test/classes/Error_Test.cls
@@ -1,0 +1,22 @@
+@IsTest 
+public with sharing class Error_Test {
+
+	private static final String CALL_LOG = 'calls';
+	private static List<Object> deferredCalls;
+
+	@TestSetup
+	private static void prepareData() {
+		insert new Account(Name = 'Acme'); // Note: SampleBatch iterates over Accounts
+	}
+
+	@IsTest
+	private static void showErrorDuringTest() {		
+
+		// Execute
+		Chainable chain = new SampleInternalErrorDuringTest()
+									.setShared(CALL_LOG, new List<String>())
+									.execute();
+
+	}
+
+}

--- a/force-app/main/test/classes/Error_Test.cls-meta.xml
+++ b/force-app/main/test/classes/Error_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/test/classes/SampleDataBatch.cls
+++ b/force-app/main/test/classes/SampleDataBatch.cls
@@ -1,0 +1,18 @@
+public class SampleDataBatch extends ChainableDataBatch {
+
+	protected override Database.QueryLocator start(Context ctx) {
+		Chainable_Test.log(this);
+
+        return Database.getQueryLocator([SELECT Phone FROM Account]);
+	}
+
+
+	protected override void execute(Context ctx, List<SObject> scope) {
+		Chainable_Test.log(this);
+	}
+
+
+	protected override void finish(Context ctx) {
+		Chainable_Test.log(this);
+	}
+}

--- a/force-app/main/test/classes/SampleDataBatch.cls-meta.xml
+++ b/force-app/main/test/classes/SampleDataBatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/test/classes/SampleInternalErrorDuringTest.cls
+++ b/force-app/main/test/classes/SampleInternalErrorDuringTest.cls
@@ -1,0 +1,18 @@
+public class SampleInternalErrorDuringTest extends ChainableBatch {
+
+	protected override Iterable<Object> start(Context ctx) {
+		Chainable_Test.log(this);
+
+        return Database.getQueryLocator([SELECT Phone FROM Account]);
+	}
+
+
+	protected override void execute(Context ctx, Iterable<Object> scope) {
+		Chainable_Test.log(this);
+	}
+
+
+	protected override void finish(Context ctx) {
+		Chainable_Test.log(this);
+	}
+}

--- a/force-app/main/test/classes/SampleInternalErrorDuringTest.cls-meta.xml
+++ b/force-app/main/test/classes/SampleInternalErrorDuringTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
I was getting an internal salesforce.com error when using chainable with the List<Sobject> / QueryIterator based version of Database.batchable classes. I am not sure how it allowed me to even deploy these types of classes when inheriting from Chainablebatch. I created a specific ChainableDataBatch to give explicit signatures for the List<Sobject> / QueryIterator based versions of those class execution paths. 

I will whip up an example error trigger if anyone is interested.